### PR TITLE
Make extension lowercase

### DIFF
--- a/rc/coderun.kak
+++ b/rc/coderun.kak
@@ -31,7 +31,7 @@ define-command -params 0..1 -file-completion -docstring 'coderun [<filename>]: r
 		FILE=$(basename "${1:-$kak_buffile}")
 		FULL="$DIRECTORY/$FILE"
 		NAME="${FILE%.*}"
-		EXTENSION=$(printf '%s' "$FILE" | sed -e "s/^$NAME\.*//" -e 's/+/p/g' -e 's/-/_/g')
+		EXTENSION=$(printf '%s' "$FILE" | sed -e "s/^$NAME\.*//" -e 's/+/p/g' -e 's/-/_/g' | tr '[:upper:]' '[:lower:]')
 
 
 		# Start


### PR DESCRIPTION
This makes the tool easier to use by automatically converting the extension into lowercase.

I prefer my r files to be called .R instead of .r, and to avoid having to create two variables (CODERUN_r and CODERUN_R) which would become hard to maintain having the script convert the extension into lowercase felt like the better solution.