### PR TITLE
Trap CTRL-C and check for ENTER key

### DIFF
--- a/rc/coderun.kak
+++ b/rc/coderun.kak
@@ -35,6 +35,6 @@ define-command -params 0..1 -file-completion -docstring 'coderun [<filename>]: r
 
 
 		# Start
-		eval "printf '%s' \"trap ':' SIGINT; $(eval "printf '%s' \"\$CODERUN_$EXTENSION\""); while read -t 0.01; do :; done; printf '\\n\\033[1mFinished (press enter to exit)\\033[0m' && while : ; do read -s -N 1 key ; if [[ \\\$key == $'\\x0a' ]] ; then break ; fi ; done\""
+		eval "printf '%s' \"trap ':' SIGINT; $(eval "printf '%s' \"\$CODERUN_$EXTENSION\""); while read -t 0.01; do :; done; printf '\\n\\033[1mCoderun ended (press enter to exit)\\033[0m' && while : ; do read -s -N 1 key ; if [[ \\\$key == $'\\x0a' ]] ; then break ; fi ; done\""
 	}
 }

--- a/rc/coderun.kak
+++ b/rc/coderun.kak
@@ -35,6 +35,6 @@ define-command -params 0..1 -file-completion -docstring 'coderun [<filename>]: r
 
 
 		# Start
-		eval "printf '%s' \"$(eval "printf '%s' \"\$CODERUN_$EXTENSION\""); printf '\\n\\033[1mCoderun ended (press enter to exit)\\033[0m' && read enter\""
+		eval "printf '%s' \"trap ':' SIGINT; $(eval "printf '%s' \"\$CODERUN_$EXTENSION\""); printf '\\n\\033[1mFinished (press enter to exit)\\033[0m' && while : ; do read -s -N 1 key ; if [[ \\\$key == $'\\x0a' ]] ; then break ; fi ; done\""
 	}
 }

--- a/rc/coderun.kak
+++ b/rc/coderun.kak
@@ -35,6 +35,6 @@ define-command -params 0..1 -file-completion -docstring 'coderun [<filename>]: r
 
 
 		# Start
-		eval "printf '%s' \"trap ':' SIGINT; $(eval "printf '%s' \"\$CODERUN_$EXTENSION\""); printf '\\n\\033[1mFinished (press enter to exit)\\033[0m' && while : ; do read -s -N 1 key ; if [[ \\\$key == $'\\x0a' ]] ; then break ; fi ; done\""
+		eval "printf '%s' \"trap ':' SIGINT; $(eval "printf '%s' \"\$CODERUN_$EXTENSION\""); while read -t 0.01; do :; done; printf '\\n\\033[1mFinished (press enter to exit)\\033[0m' && while : ; do read -s -N 1 key ; if [[ \\\$key == $'\\x0a' ]] ; then break ; fi ; done\""
 	}
 }


### PR DESCRIPTION
The first thing this change does is to trap the sigint into no-op to not make the terminal close itself after ctrl-c has been used. 
If I exit my code I still might want to look at the output (it might only be my terminal that instantly closes itself but both kitty and xterm had this behavior). This way the code exists and waits for the enter character. 

The second change is to check what character is read from the terminal. Instead of quitting after reading any character, it now continues to check until the character read is the enter key.

It also clears the inputbuffer before checking for the enter key. This is so that even if you pressed enter while running your program that it never read/removed from the input buffer. The terminal will not close instantly after finishing (because it read the buffered enter and quit). You will have to press enter after the "Coderun ended" promt.